### PR TITLE
Fail when can't create public key

### DIFF
--- a/ssh-keygen.c
+++ b/ssh-keygen.c
@@ -2860,9 +2860,16 @@ passphrase_again:
 		    identity_file, strerror(errno));
 	if ((f = fdopen(fd, "w")) == NULL)
 		fatal("fdopen %s failed: %s", identity_file, strerror(errno));
-	if ((r = sshkey_write(public, f)) != 0)
+	if ((r = sshkey_write(public, f)) != 0) {
 		error("write key failed: %s", ssh_err(r));
-	fprintf(f, " %s\n", comment);
+		exit(1);
+	}
+	if (-1 == fprintf(f, " %s", comment))
+		error("add comment to %s failed", identity_file);
+	if ('\n' != fputc('\n', f)) {
+		error("write newline %s failed: %s", identity_file, strerror(errno));
+		exit(1);
+	}
 	fclose(f);
 
 	if (!quiet) {


### PR DESCRIPTION
ssh-keygen should exit with a failure result code (non-zero) if the public key cannot be written to the public identity file or if a trailing newline cannot be written to the public identity file. Either of these conditions prevents the user from generating a valid `authorized_keys` file with the de-facto standard `cat id_whatever.pub >> authorized_keys` mechanism.

Setting correct exit codes is important for the benefit of automation which invokes ssh-keygen.

I have chosen to log and not fail if the comment cannot be written because it's an optional field.